### PR TITLE
pull with --prune

### DIFF
--- a/bin/update-repos.sh
+++ b/bin/update-repos.sh
@@ -4,13 +4,12 @@ update_repos::main(){
     local depth=${1:-2}
 
     read -r -d '' parallel_commands <<- EOF
-git -C {} pull --rebase ;
-git -C {} fetch --prune ;
+git -C {} pull --rebase --prune;
 echo job {#} completed {}
 EOF
 	echo "$parallel_commands"
     find . -maxdepth "${depth}" \( -type l -o -type d \) -exec test -e '{}/.git' ';' -print -prune | \
-    parallel -j 50 "${parallel_commands}"
+    parallel --retry-failed --retries 3 -j 55 "${parallel_commands}"
 }
 
 update_repos::main "$@"


### PR DESCRIPTION
https://git-scm.com/docs/git-pull

```text
--prune
Before fetching, remove any remote-tracking references that no longer exist on the remote. Tags are not subject to pruning if they are fetched only because of the default tag auto-following or due to a --tags option. However, if tags are fetched due to an explicit refspec (either on the command line or in the remote configuration, for example if the remote was cloned with the --mirror option), then they are also subject to pruning. Supplying --prune-tags is a shorthand for providing the tag refspec.
```